### PR TITLE
fix(package): mark tape as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "tape": "^2.13.1"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/maxogden/google-spreadsheets-key-parser.git"


### PR DESCRIPTION
When installing `google-spreadsheets-key-parser`, `npm audit` returns a high-severity warning due to the old version of `tape` being used. However, this warning is avoidable, as `tape` does not need to be a production `dependency`. Instead, it can be changed to a `devDependency`, which will prevent this audit warning from appearing for consumers of `google-spreadsheets-key-parser`.